### PR TITLE
Fix 'Cannot find module' issue and other problems related to Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
-import { extractAll, createPackageWithOptions } from "asar";
-import { readdirSync, readFileSync, writeFileSync, existsSync } from "fs";
-import { sync } from "rimraf";
-import { dirname } from "path";
-import { spawn } from "child_process";
+const { extractAll, createPackageWithOptions } = require("asar");
+const { readdirSync, readFileSync, writeFileSync, existsSync } = require("fs");
+const { sync } = require("rimraf");
+const { dirname } = require("path");
+const { spawn } = require("child_process");
 
 function replaceAdFileContent(fileName, assetDir) {
   let content = readFileSync(`${assetDir}/${fileName}`).toString();

--- a/index.js
+++ b/index.js
@@ -1,12 +1,11 @@
 const { extractAll, createPackageWithOptions } = require("asar");
 const { readdirSync, readFileSync, writeFileSync, existsSync } = require("fs");
 const { sync } = require("rimraf");
-const { dirname } = require("path");
+const { dirname, normalize } = require("path");
 const { spawn } = require("child_process");
-const path = require("path");
 
 function replaceAdFileContent(fileName, assetDir) {
-  const contentPath = path.normalize(`${assetDir}/${fileName}`);
+  const contentPath = normalize(`${assetDir}/${fileName}`);
   let content = readFileSync(contentPath).toString();
 
   content = content.replaceAll(
@@ -40,7 +39,7 @@ async function rebuildAddDir(asarFilePath) {
   console.log("Unpacking OPGG asar file");
   extractAll(asarFilePath, "op-gg-unpacked");
 
-  const assetDir = path.normalize("op-gg-unpacked/assets/react");
+  const assetDir = normalize("op-gg-unpacked/assets/react");
   const assetFiles = readdirSync(assetDir);
 
   for (let fileName of assetFiles) {
@@ -72,10 +71,10 @@ function main() {
    * Use path.normalize to use ensure the right slash is used based on the
    * operating system, forward slash or backward slash.
    */
-  const darwinPath = path.normalize(
+  const darwinPath = normalize(
     "/Applications/OP.GG.app/Contents/Resources/app.asar"
   );
-  const winPath = path.normalize(
+  const winPath = normalize(
     `${dirname(process.env.APPDATA)}/Local/Programs/OP.GG/resources/app.asar`
   );
   const asarFilePath = process.platform === "darwin" ? darwinPath : winPath;


### PR DESCRIPTION
### Changes
* Change imports to use CommonJS-style, fixes #1
* Refactor code to normalize paths (uses correct slash based on operating system).
* Code housekeeping for readability. :3


Building on Windows and running the executable appears to work successfully (kill OP.GG, removes ads). Not sure if it still works on Darwin, you should check on that.